### PR TITLE
Implement logout loader

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { THEME } from "./helpers/GetStaticData.js";
 import { Router } from "./routes/Router.jsx";
 import { useAlertStore } from "./store/alert-store.js";
 import { useSessionStore } from "./store/session-store.js";
+import { GenericLoader } from "./components/generic-loader/GenericLoader";
 import PostHogPageviewTracker from "./PostHogPageviewTracker.js";
 import { PageTitle } from "./components/widgets/page-title/PageTitle.jsx";
 import { useEffect } from "react";
@@ -23,7 +24,7 @@ try {
 function App() {
   const [notificationAPI, contextHolder] = notification.useNotification();
   const { defaultAlgorithm, darkAlgorithm } = theme;
-  const { sessionDetails } = useSessionStore();
+  const { sessionDetails, isLogoutLoading } = useSessionStore();
   const { alertDetails } = useAlertStore();
   const { pushLogMessages } = useSocketLogsStore();
 
@@ -86,6 +87,11 @@ function App() {
       }}
     >
       <HelmetProvider>
+        {isLogoutLoading && (
+          <div className="fullscreen-loader">
+            <GenericLoader />
+          </div>
+        )}
         <BrowserRouter>
           <PostHogPageviewTracker />
           <PageTitle title={"Unstract"} />

--- a/frontend/src/hooks/useLogout.js
+++ b/frontend/src/hooks/useLogout.js
@@ -1,3 +1,4 @@
+import axios from "axios";
 import Cookies from "js-cookie";
 import { usePostHog } from "posthog-js/react";
 import { getSessionData } from "../helpers/GetSessionData";
@@ -6,6 +7,7 @@ import { useSessionStore } from "../store/session-store";
 
 function useLogout() {
   const setSessionDetails = useSessionStore((state) => state.setSessionDetails);
+  const setLogoutLoading = useSessionStore((state) => state.setLogoutLoading);
   const posthog = usePostHog();
 
   const clearSessionCookies = () => {
@@ -13,13 +15,19 @@ function useLogout() {
     Cookies.remove("csrftoken");
   };
 
-  return () => {
+  return async () => {
+    setLogoutLoading(true);
     setSessionDetails(getSessionData(null));
     posthog.reset();
     clearSessionCookies();
     const baseUrl = getBaseUrl();
-    const newURL = baseUrl + "/api/v1/logout";
-    window.location.href = newURL;
+    try {
+      await axios.get(baseUrl + "/api/v1/logout");
+    } catch (error) {
+      // ignore errors and proceed to navigation
+    }
+    setLogoutLoading(false);
+    window.location.href = baseUrl + "/";
   };
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -235,3 +235,13 @@ body {
 .mar-0{
   margin: 0;
 }
+
+.fullscreen-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background-color: #ffffff;
+  z-index: 2000;
+}

--- a/frontend/src/store/session-store.js
+++ b/frontend/src/store/session-store.js
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 const STORE_VARIABLES = {
   sessionDetails: {},
+  isLogoutLoading: false,
 };
 const useSessionStore = create((setState, getState) => ({
   ...STORE_VARIABLES,
@@ -14,6 +15,9 @@ const useSessionStore = create((setState, getState) => ({
     setState(() => {
       return { sessionDetails: { ...getState().sessionDetails, ...details } };
     });
+  },
+  setLogoutLoading: (loading) => {
+    setState(() => ({ isLogoutLoading: loading }));
   },
 }));
 


### PR DESCRIPTION
## Summary
- show GenericLoader overlay during logout
- track logout status in session store
- block UI while backend logout completes

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3f2d71748321a5c007900443bd5c